### PR TITLE
ci(github-actions): add daily-run workflow for building and executing…

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -1,0 +1,38 @@
+name: daily-run
+
+on:
+  schedule:
+    - cron: "0 19 * * *"
+
+jobs:
+  build-and-execute:
+    environment: user
+
+    runs-on: ubuntu-latest
+
+    if: github.ref == 'refs/heads/master'
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install rust default
+        run: rustup update stable && rustup default stable
+
+      - name: Rust cache
+        uses: swatinem/rust-cache@v2
+        with:
+          workspaces: ". -> target"
+
+      - name: Build
+        run: |
+          cd cli
+          cargo build --release
+        env:
+          BACKEND: ${{ secrets.BACKEND }}
+
+      - name: Execute
+        run: ./target/release/clia \
+          -u ${{ secrets.USERNAME }} \
+          -p ${{ secrets.PASSWORD }} \
+          -m 5 \
+          -r ./assets/map.geojson


### PR DESCRIPTION
… CLI

- Introduced a new GitHub Action workflow (`daily.yml`) to run on a daily schedule at 19:00 UTC.
- The workflow checks out the code, updates Rust to the latest stable version, and caches dependencies for faster builds.
- Builds the CLI project and executes it with predefined secrets for username, password, mileage, and route.
- Designed to run only on the `master` branch.