### PR TITLE
chore(deps): update `cc` crate and improve time parsing logic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -379,9 +379,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.1.26"
+version = "1.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4cbd4ab9fef358caa9c599eae3105af638ead5fb47a718315d8e03c852b9f0d"
+checksum = "2e80e3b6a3ab07840e1cae9b0666a63970dc28e8ed5ffbcdacbfc760c281bfc1"
 dependencies = [
  "shlex",
 ]

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -19,7 +19,10 @@
 use std::{fs::File, io::Read};
 
 use clap::Parser;
-use lib::{Account, DateTime, Local};
+use lib::{
+    chrono::{Local, NaiveDateTime},
+    Account,
+};
 use log::{debug, info, Level, Metadata, Record};
 
 struct SimpleLogger {
@@ -84,9 +87,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     account.login(&args.username, &args.password).await?;
 
     let time = match args.time {
-        Some(time) => {
-            DateTime::parse_from_str(&time, "%Y-%m-%d %H:%M:%S").map(|t| t.with_timezone(&Local))?
-        }
+        Some(time) => NaiveDateTime::parse_from_str(&time, "%Y-%m-%d %H:%M:%S")
+            .map(|t| t.and_local_timezone(Local).earliest().unwrap())?,
         None => Local::now(),
     };
 

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -23,8 +23,8 @@ use log::{debug, info};
 use regex::Regex;
 use routine::*;
 
-pub use chrono::{DateTime, Local};
-use chrono::{Duration, Utc};
+pub use chrono;
+use chrono::{DateTime, Duration, Local, Utc};
 use rand::{thread_rng, Rng};
 use reqwest::{header::*, Client, StatusCode};
 use security::{decode_ns, sign_run_data, UploadRunningInfoBuilder};

--- a/tauri-app/src-tauri/src/lib.rs
+++ b/tauri-app/src-tauri/src/lib.rs
@@ -16,8 +16,10 @@
     along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-// Learn more about Tauri commands at https://tauri.app/v1/guides/features/command
-use lib::{Account, DateTime, Local};
+use lib::{
+    chrono::{DateTime, Local},
+    Account,
+};
 use tauri::{async_runtime::Mutex, Manager, State};
 
 #[tauri::command]


### PR DESCRIPTION
- Updated the `cc` crate to version `1.1.28` in `Cargo.lock`.
- Refined time parsing logic in the CLI:
  - Switched to using `NaiveDateTime` for parsing time strings.
  - Corrected the timezone conversion using `and_local_timezone` for better handling of timezones.
- Adjusted `lib` and `tauri-app` to correctly import `chrono` and handle time-related functionalities.