### PR TITLE
chore: bump version to 1.2.2 post migration to Deno

### DIFF
--- a/tauri-app/package.json
+++ b/tauri-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pretty-der6y",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Hachimi hachimi hachimi~",
   "type": "module",
   "author": "Fay Ash",

--- a/tauri-app/src-tauri/Cargo.toml
+++ b/tauri-app/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pretty-der6y"
-version = "1.2.1"
+version = "1.2.2"
 description = "Hachimi hachimi hachimi~"
 authors = ["Fay Ash"]
 edition = "2021"

--- a/tauri-app/src-tauri/tauri.conf.json
+++ b/tauri-app/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Pretty Der6y",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "identifier": "moe.phieash.pretty-der6y",
   "build": {
     "beforeDevCommand": "deno run dev",


### PR DESCRIPTION
- Incremented version from 1.2.1 to 1.2.2 in package.json, Cargo.toml, and tauri.conf.json
- Version bump follows the migration from Bun to Deno